### PR TITLE
Kd02109/router

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@
 ## 구현 요소
 
 - 크게 3개의 페이지로 구성됩니다. Home, Bookmark, ProductList입니다.
+
+## Router 설정
+
+- 기존 CRA로 형성한 react 템플릿에서는 BrowserRouter로 감싸는 형태로 작업하였을 때 정상적으로 출력이 되었지만, vite 템플릿에서는 작동이 되지 않아서 공식 홈페이지 듀토리얼을 참고하면서 다시 진행하였습니다.
+- [공식 블로그](https://reactrouter.com/en/main/start/tutorial)
+  - 4개의 페이지를 만들어서 기본 router 구성 Home, ProductList, Bookmark, NotFound

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,7 @@
+import Routers from "./routers/Routers";
+
 function App() {
-  return <></>;
+  return <Routers />;
 }
 
 export default App;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App.jsx";
+import { RouterProvider } from "react-router-dom";
+import router from "./routers/Routers.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>
 );

--- a/src/pages/Bookmark.jsx
+++ b/src/pages/Bookmark.jsx
@@ -1,0 +1,5 @@
+function Bookmark() {
+  return <div>bookmark</div>;
+}
+
+export default Bookmark;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,9 @@
+function Home() {
+  return (
+    <div>
+      <h1>Home</h1>
+    </div>
+  );
+}
+
+export default Home;

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,33 @@
+import { useRouteError } from "react-router-dom";
+import styled from "styled-components";
+
+const ErrorDiv = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  h1 {
+    font-size: 40px;
+  }
+  p {
+    font-size: 20px;
+  }
+`;
+
+function NotFound() {
+  const error = useRouteError();
+  return (
+    <ErrorDiv>
+      <h1>404 Not Found</h1>
+      <p>Sorry, an unexpected error has occurred.</p>
+      <p>죄송합니다. 예상치 못한 에러가 발생했습니다.</p>
+      <p>
+        <i>{error.statusText || error.message}</i>
+      </p>
+    </ErrorDiv>
+  );
+}
+
+export default NotFound;

--- a/src/pages/ProductLists.jsx
+++ b/src/pages/ProductLists.jsx
@@ -1,0 +1,5 @@
+function ProductLists() {
+  return <div>product list</div>;
+}
+
+export default ProductLists;

--- a/src/routers/Routers.jsx
+++ b/src/routers/Routers.jsx
@@ -1,0 +1,23 @@
+import { createBrowserRouter } from "react-router-dom";
+import Home from "../pages/Home";
+import NotFound from "../pages/NotFound";
+import ProductLists from "../pages/ProductLists";
+import Bookmark from "../pages/Bookmark";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <Home />,
+    errorElement: <NotFound />,
+  },
+  {
+    path: "/products/list",
+    element: <ProductLists />,
+  },
+  {
+    path: "/bookmark",
+    element: <Bookmark />,
+  },
+]);
+
+export default router;


### PR DESCRIPTION
- 기본 router 페이지 설정 
- Home, 상품페이지, bookmark, NotFound 페이지 형성

### 1. Router 설정

- 기존 CRA로 형성한 react 템플릿에서는 BrowserRouter로 감싸는 형태로 작업하였을 때 정상적으로 출력이 되었지만, vite 템플릿에서는 작동이 되지 않아서 공식 홈페이지 듀토리얼을 참고하면서 다시 진행하였습니다.
- [공식 블로그](https://reactrouter.com/en/main/start/tutorial)
  - 4개의 페이지를 만들어서 기본 router 구성 Home, ProductList, Bookmark, NotFound
  - BrowserRouter와 createBrowserRouter의 차이에 대해서 이해할 수 있었다. createBrowserRouter에서는 DataRoiter를 제공하기 때문에 더 많은 기능을 사용할 수 있었다. (ex. data APIs) 따라서 NotFound 페이지에서 사용하고 있는 useRouteError 훅은 createBrowserRouter에서만 사용가능하였다. [링크](https://reactrouter.com/en/6.11.1/routers/picking-a-router)