### PR TITLE
Kd02109/basecss

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,5 +12,6 @@ module.exports = {
   plugins: ["react-refresh"],
   rules: {
     "react-refresh/only-export-components": "warn",
+    "prettier/prettier": ["error", { endOfLine: "auto" }],
   },
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "parser": "flow",
+  "endOfLine": "auto"
+}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@
 ## 구현 요소
 
 - 크게 3개의 페이지로 구성됩니다. Home, Bookmark, ProductList입니다.
+
+## Router 설정
+
+- 기존 CRA로 형성한 react 템플릿에서는 BrowserRouter로 감싸는 형태로 작업하였을 때 정상적으로 출력이 되었지만, vite 템플릿에서는 작동이 되지 않아서 공식 홈페이지 듀토리얼을 참고하면서 다시 진행하였습니다.
+- [공식 블로그](https://reactrouter.com/en/main/start/tutorial)
+  - 4개의 페이지를 만들어서 기본 router 구성 Home, ProductList, Bookmark, NotFound

--- a/README.md
+++ b/README.md
@@ -10,8 +10,13 @@
 
 - 크게 3개의 페이지로 구성됩니다. Home, Bookmark, ProductList입니다.
 
-## Router 설정
+### 1. Router 설정
 
 - 기존 CRA로 형성한 react 템플릿에서는 BrowserRouter로 감싸는 형태로 작업하였을 때 정상적으로 출력이 되었지만, vite 템플릿에서는 작동이 되지 않아서 공식 홈페이지 듀토리얼을 참고하면서 다시 진행하였습니다.
 - [공식 블로그](https://reactrouter.com/en/main/start/tutorial)
   - 4개의 페이지를 만들어서 기본 router 구성 Home, ProductList, Bookmark, NotFound
+
+### 2. 기본 CSS 설정
+- styledComponent의 전역 스타일 설정하기, `createGlobalStyle`를 활용했습니다. 그리고 reset css를 적용했습니다. [reset css](https://meyerweb.com/eric/tools/css/reset/)
+- styledComponent Theme을 활용해서 기본적으로 사용하는 폰트의 크기, 각 margin 값, color를 설정했습니다. 
+- reset css로 인해 변화된 NotFound Page의 css를 수정했습니다.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,7 @@
+import Routers from "./routers/Routers";
+
 function App() {
-  return <></>;
+  return <Routers />;
 }
 
 export default App;

--- a/src/GlobalStyle.jsx
+++ b/src/GlobalStyle.jsx
@@ -1,0 +1,55 @@
+import { createGlobalStyle } from "styled-components";
+// 전역 reset css 형성
+// https://meyerweb.com/eric/tools/css/reset/
+const GlobalStyle = createGlobalStyle`
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}
+#root {
+ width: 100vw;
+ height: 100vh;
+
+}
+`;
+
+export default GlobalStyle;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,15 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import router from "./routers/Routers.jsx";
+import GlobalStyle from "./GlobalStyle.jsx";
+import { ThemeProvider } from "styled-components";
+import theme from "./theme.js";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <ThemeProvider theme={theme}>
+      <GlobalStyle />
+      <RouterProvider router={router} />
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App.jsx";
+import { RouterProvider } from "react-router-dom";
+import router from "./routers/Routers.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>
 );

--- a/src/pages/Bookmark.jsx
+++ b/src/pages/Bookmark.jsx
@@ -1,0 +1,5 @@
+function Bookmark() {
+  return <div>bookmark</div>;
+}
+
+export default Bookmark;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,9 @@
+function Home() {
+  return (
+    <div>
+      <h1>Home</h1>
+    </div>
+  );
+}
+
+export default Home;

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -9,10 +9,13 @@ const ErrorDiv = styled.div`
   justify-content: center;
   align-items: center;
   h1 {
-    font-size: 40px;
+    font-size: ${(props) => props.theme.title};
+    margin-bottom: 20px;
+    color: #e84118;
   }
   p {
     font-size: 20px;
+    margin-bottom: 20px;
   }
 `;
 
@@ -21,7 +24,6 @@ function NotFound() {
   return (
     <ErrorDiv>
       <h1>404 Not Found</h1>
-      <p>Sorry, an unexpected error has occurred.</p>
       <p>죄송합니다. 예상치 못한 에러가 발생했습니다.</p>
       <p>
         <i>{error.statusText || error.message}</i>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,33 @@
+import { useRouteError } from "react-router-dom";
+import styled from "styled-components";
+
+const ErrorDiv = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  h1 {
+    font-size: 40px;
+  }
+  p {
+    font-size: 20px;
+  }
+`;
+
+function NotFound() {
+  const error = useRouteError();
+  return (
+    <ErrorDiv>
+      <h1>404 Not Found</h1>
+      <p>Sorry, an unexpected error has occurred.</p>
+      <p>죄송합니다. 예상치 못한 에러가 발생했습니다.</p>
+      <p>
+        <i>{error.statusText || error.message}</i>
+      </p>
+    </ErrorDiv>
+  );
+}
+
+export default NotFound;

--- a/src/pages/ProductLists.jsx
+++ b/src/pages/ProductLists.jsx
@@ -1,0 +1,5 @@
+function ProductLists() {
+  return <div>product list</div>;
+}
+
+export default ProductLists;

--- a/src/routers/Routers.jsx
+++ b/src/routers/Routers.jsx
@@ -1,0 +1,23 @@
+import { createBrowserRouter } from "react-router-dom";
+import Home from "../pages/Home";
+import NotFound from "../pages/NotFound";
+import ProductLists from "../pages/ProductLists";
+import Bookmark from "../pages/Bookmark";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <Home />,
+    errorElement: <NotFound />,
+  },
+  {
+    path: "/products/list",
+    element: <ProductLists />,
+  },
+  {
+    path: "/bookmark",
+    element: <Bookmark />,
+  },
+]);
+
+export default router;

--- a/src/theme.js
+++ b/src/theme.js
@@ -8,6 +8,8 @@ const theme = {
   title: "40px",
   percentColor: "#452CDD",
   footerColor: "#888888",
+  outerMargin: "76px",
+  cardMargin: "24px",
 };
 
 export default theme;

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,13 @@
+const theme = {
+  font: {
+    large: "32px",
+    medium: "24px",
+    small: "16px",
+    footer: "12px",
+  },
+  title: "40px",
+  percentColor: "#452CDD",
+  footerColor: "#888888",
+};
+
+export default theme;


### PR DESCRIPTION
- prettier LF, CRLF 에러 수정
- styledcomponent의 GlobalStyle, theme 설정 
- NotFound.jsx css 일부 수정 

### 2. 기본 CSS 설정
- styledComponent의 전역 스타일 설정하기, `createGlobalStyle`를 활용했습니다. 그리고 reset css를 적용했습니다. [reset css](https://meyerweb.com/eric/tools/css/reset/)
- styledComponent Theme을 활용해서 기본적으로 사용하는 폰트의 크기, 각 margin 값, color를 설정했습니다. 
- reset css로 인해 변화된 NotFound Page의 css를 수정했습니다.